### PR TITLE
Hacer que las imagenes aparezcan

### DIFF
--- a/AppBamp/models.py
+++ b/AppBamp/models.py
@@ -8,7 +8,7 @@ class Ciudad(models.Model):
 class CategoriaRestaurante(models.Model):
     idCategoriaRestaurante = models.CharField(max_length = 5)
     nombreCategoriaRestaurante = models.CharField(max_length = 50)
-    imagen= models.ImageField(upload_to=None, height_field=None, width_field=None, max_length=100)
+    imagen= models.ImageField(upload_to='imagenes_categoria_restaurante', height_field=None, width_field=None, max_length=100)
 
 
     def __str__(self):

--- a/AppBamp/templates/categorias_restaurante.html
+++ b/AppBamp/templates/categorias_restaurante.html
@@ -78,9 +78,7 @@
 <div class="container">
     {% for obj in categorias %}
       <div class="category">
-  
-          <img src="imagen" alt="{{ obj.imagen }}">
-    
+          <img src="{{ obj.imagen.url }}" alt="Imagen de la Categoria.">
       </div>
     {% endfor %}
   </div>

--- a/Bamp/settings.py
+++ b/Bamp/settings.py
@@ -11,9 +11,12 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
 
 
 # Quick-start development settings - unsuitable for production
@@ -63,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.media',
             ],
         },
     },

--- a/Bamp/urls.py
+++ b/Bamp/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
+from django.conf.urls.static import static
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('bamp/', include('AppBamp.urls'))
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+asgiref==3.7.2
+Django==4.2.7
+Pillow==10.1.0
+sqlparse==0.4.4
+typing_extensions==4.8.0


### PR DESCRIPTION
Razones por las que no cargaban las imágenes:

- En `settings.py` hay que poner unas variables que definen donde se almacena el contenido media.
- En `settings.py` hay que añadir `'django.template.context_processors.media'` en la seccion de `TEMPLATES` para cargar bien las imágenes desde los templates (el html).
- Faltaba un poco de configuración en `urls.py`, echarle un vistazo.
- En el modelo, en vez de poner `upload_to=None` hay que poner la carpeta en la que quieres que se guarden las imágenes (que estará por defecto dentro de la carpeta media). Por ejemplo: `upload_to='imagenes_categoria_restaurante'`, y las imagenes se guardaran dentro de `/media/imagenes_categoria_restaurante`.
- En el HTML estabais poniendo la ruta de la imagen en el alt en vez de el src. También relacionado con esto, hay que poner `imagen.url` para que la ruta se calcule bien y no solo `imagen`.

PD: El archivo `requirements.txt` viene bien para alguien ejecutando la aplicación desde su ordenador por primera vez. Lo podéis sacar con el comando `pip freeze` (o `pip3 freeze` si usáis `pip3`).